### PR TITLE
Bugfix: cast items with target "TARGET_DEST_NEARBY_ENTRY" (e.g. item …

### DIFF
--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -3415,6 +3415,8 @@ void Spell::prepare(SpellCastTargets const* targets, AuraEffect const* triggered
     if (m_CastItem)
     {
         bool selectTargets = false;
+        bool nearbyDest = false;
+
         for (uint8 i = EFFECT_0; i < MAX_SPELL_EFFECTS; ++i)
         {
             if (!m_spellInfo->Effects[i].IsEffect())
@@ -3426,6 +3428,11 @@ void Spell::prepare(SpellCastTargets const* targets, AuraEffect const* triggered
                 break;
             }
 
+            if (m_spellInfo->Effects[i].TargetA.GetObjectType() == TARGET_OBJECT_TYPE_DEST)
+            {
+                nearbyDest = true;
+            }
+
             // xinef: by default set it to false, and to true if any valid target is found
             selectTargets = true;
         }
@@ -3434,8 +3441,26 @@ void Spell::prepare(SpellCastTargets const* targets, AuraEffect const* triggered
         {
             SelectSpellTargets();
             _spellTargetsSelected = true;
+            bool spellFailed = false;
 
             if (m_UniqueTargetInfo.empty() && m_UniqueGOTargetInfo.empty())
+            {
+                // no valid nearby target unit or game object found; check if nearby destination type
+                if (nearbyDest)
+                {
+                    if (!m_targets.HasDst())
+                    {
+                        // no valid target destination
+                        spellFailed = true;
+                    }
+                }
+                else
+                {
+                    spellFailed = true;
+                }
+            }
+
+            if (spellFailed)
             {
                 SendCastResult(SPELL_FAILED_CASTER_AURASTATE);
                 finish(false);


### PR DESCRIPTION
…7247) did not work because the if-clause only checks valid target units or game objects; fixed via additional check for target object type "TARGET_OBJECT_TYPE_DEST" and a valid target destination

**Changes proposed:**

-  
-  
-  

**Target branch(es):** 1.x/2.x etc.

**Issues addressed:** Closes #

**Tests performed:** (Does it build, tested in-game, etc)

**Known issues and TODO list:**

- [ ] 
- [ ] 

**NOTE** You no longer need to squash your commits, on merge we will squash it for you. (GitHub added a new feature)


